### PR TITLE
Avoid kvm websocket from closing when docker container startup takes some time..

### DIFF
--- a/kvm_handler.py
+++ b/kvm_handler.py
@@ -17,6 +17,7 @@ from nojava_ipmi_kvm.kvm import (
 )
 from nojava_ipmi_kvm.config import config, HTML5HostConfig
 from nojava_ipmi_kvm import utils
+from tornado import gen
 
 from basehandler import BaseWSHandler
 
@@ -46,6 +47,7 @@ class KVMHandler(BaseWSHandler):
 
         logging.info("Websocket opened by %s", self._current_user["name"])
 
+    @gen.coroutine
     async def on_message(self, msg):
         logging.info("Websocket from %s said %s", self._current_user["name"], msg)
 


### PR DESCRIPTION
This PR ensures long docker startup does not block websocket communications, otherwise tornado may close the socket due to pong responses not being processed timely.

Currently on_message method awaits on call to start_kvm_container(), but this forbids tornado's IOLoop from processing pong messages coming back from browser. Which in turns ends up making tornado assume the socket is dead an close the connection.

By making the on_message call a coroutine, it is dispatched 'on a coroutine', thus allowing tornado's IOLoop to move right away to the next websocket event.

