### PR TITLE
Enhance error handling & logging when container cannot be started.

### DIFF
--- a/kvm_handler.py
+++ b/kvm_handler.py
@@ -133,7 +133,6 @@ class KVMHandler(BaseWSHandler):
                             self._current_session.kill_process()
                     except:
                         pass
-                    return
 
                 if isinstance(sess, HTML5KvmViewer):
                     return self.write_message(

--- a/kvm_handler.py
+++ b/kvm_handler.py
@@ -123,6 +123,7 @@ class KVMHandler(BaseWSHandler):
                     started = True
                 except WebSocketError as ex:
                     logging.exception("Could not start KVM container: WebSocket closed unexpectedly?")
+                    return
                 except Exception as ex:
                     logging.exception("Could not start KVM container: %s" % ex)
                     return self.write_message({"action": "error", "message": str(ex)})


### PR DESCRIPTION
Enhance kvm_handler, as to try to handle container disposal in cases where an unexpected error raises during container startup.
And also handle WebSocket failures, as to avoid trying to write to a (possible) closed socket, thus raising a new exception shadowing the actual container startup error.